### PR TITLE
Fix Spamming Extra Toggle Exploit

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -220,27 +220,16 @@ AddEventHandler('qb-radialmenu:client:setExtra', function(data)
     local extra = tonumber(replace)
     local ped = PlayerPedId()
     local veh = GetVehiclePedIsIn(ped)
-    local enginehealth = 1000.0
-    local bodydamage = 1000.0
-
     if veh ~= nil then
         local plate = GetVehicleNumberPlateText(closestVehicle)
-    
         if GetPedInVehicleSeat(veh, -1) == PlayerPedId() then
+            SetVehicleAutoRepairDisabled(veh, true) -- Forces Auto Repair off when Toggling Extra [GTA 5 Niche Issue]
             if DoesExtraExist(veh, extra) then 
                 if IsVehicleExtraTurnedOn(veh, extra) then
-                    enginehealth = GetVehicleEngineHealth(veh)
-                    bodydamage = GetVehicleBodyHealth(veh)
                     SetVehicleExtra(veh, extra, 1)
-                    SetVehicleEngineHealth(veh, enginehealth)
-                    SetVehicleBodyHealth(veh, bodydamage)
                     QBCore.Functions.Notify('Extra ' .. extra .. ' Deactivated', 'error', 2500)
                 else
-                    enginehealth = GetVehicleEngineHealth(veh)
-                    bodydamage = GetVehicleBodyHealth(veh)
                     SetVehicleExtra(veh, extra, 0)
-                    SetVehicleEngineHealth(veh, enginehealth)
-                    SetVehicleBodyHealth(veh, bodydamage)
                     QBCore.Functions.Notify('Extra ' .. extra .. ' Activated', 'success', 2500)
                 end    
             else


### PR DESCRIPTION
Spamming Extras through menu will allow your vehicle to be repaired and fuel to be topped and all sorts of weird issues using SetVehicleAutoRepairDisabled Native fixes all these issues.