### PR TITLE
Update attach coords when player is close

### DIFF
--- a/client/stretcher.lua
+++ b/client/stretcher.lua
@@ -93,7 +93,7 @@ local function LayOnStretcher()
             loadAnim(inBedDicts)
             if stretcherObject and #(coords - GetEntityCoords(stretcherObject)) <= 3.0 then
                 TaskPlayAnim(PlayerPedId(), inBedDicts, inBedAnims, 8.0, 8.0, -1, 69, 1, false, false, false)
-                AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.6, 0.0, 0.0, 360.0, 0.0, false, false, false, false, 2, true)
+                AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.0, 0.0, 0.0, 180.0, 0.0, false, false, false, false, 2, true)
                 isLayingOnBed = true
             end
         end
@@ -129,7 +129,7 @@ local function attachToStretcher()
                 loadAnim("anim@heists@box_carry@")
                 TaskPlayAnim(ped, 'anim@heists@box_carry@', 'idle', 8.0, 8.0, -1, 50, 0, false, false, false)
                 SetTimeout(150, function()
-                    AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -1.0, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2, true)
+                    AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -0.50, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2, true)
                 end)
                 FreezeEntityPosition(stretcherObject, false)
             end

--- a/client/stretcher.lua
+++ b/client/stretcher.lua
@@ -243,7 +243,7 @@ RegisterNetEvent('qb-radialmenu:client:Result', function(isBusy, type)
             NetworkRequestControlOfEntity(stretcherObject)
             loadAnim(inBedDicts)
             TaskPlayAnim(ped, inBedDicts, inBedAnims, 8.0, 8.0, -1, 69, 1, false, false, false)
-            AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.6, 0.0, 0.0, 360.0, 0.0, false, false, false, false, 2, true)
+            AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.0, 0.0, 0.0, 180.0, 0.0, false, false, false, false, 2, true)
             isLayingOnBed = true
         else
             QBCore.Functions.Notify(Lang:t("error.stretcher_in_use"), "error")
@@ -255,7 +255,7 @@ RegisterNetEvent('qb-radialmenu:client:Result', function(isBusy, type)
             loadAnim("anim@heists@box_carry@")
             TaskPlayAnim(ped, 'anim@heists@box_carry@', 'idle', 8.0, 8.0, -1, 50, 0, false, false, false)
             SetTimeout(150, function()
-                AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -1.0, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2, true)
+                AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -0.50, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2, true)
             end)
             FreezeEntityPosition(stretcherObject, false)
             isAttached = true


### PR DESCRIPTION
There's a bug where if another player is close they end up floating above the stretcher or the stretcher is sunk into the ground as they carry. This sets the coords to the same regardless of who is around.