### PR TITLE
[Update] Dynamic Menu Options + Hold/Release

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -4,7 +4,7 @@ local inRadialMenu = false
 
 -- Functions
 
-RegisterKeyMapping('radialmenu', Lang:t("general.command_description"), 'keyboard', 'Z')
+RegisterKeyMapping('radialmenu2', Lang:t("general.command_description"), 'keyboard', 'F1')
 
 -- Sets the metadata when the player spawns
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,23 +1,21 @@
 QBCore = exports['qb-core']:GetCoreObject()
 PlayerData = QBCore.Functions.GetPlayerData() -- Setting this for when you restart the resource in game
 local inRadialMenu = false
-local radialMenuSetup = false
 
 -- Functions
 
 local function SetupJobMenu()
-    local index = #Config.MenuItems + 1
     if PlayerData.metadata["isdead"] then
         if PlayerData.job.name == "police" or PlayerData.job.name == "ambulance" then
-            if not Config.MenuItems[index] then
-                Config.MenuItems[index] = {
+            if not Config.MenuItems[4] then
+                Config.MenuItems[4] = {
                     id = 'jobinteractions',
                     title = 'Work',
                     icon = 'briefcase',
                     items = {}
                 }
             end
-            Config.MenuItems[index].items = {
+            Config.MenuItems[4].items = {
                 [1] = {
                     id = 'emergencybutton2',
                     title = Lang:t("options.emergency_button"),
@@ -30,35 +28,37 @@ local function SetupJobMenu()
         else
             if Config.JobInteractions[PlayerData.job.name] and
                 next(Config.JobInteractions[PlayerData.job.name]) then
-                if not Config.MenuItems[index] then
-                    Config.MenuItems[index] = {
+                if not Config.MenuItems[4] then
+                    Config.MenuItems[4] = {
                         id = 'jobinteractions',
                         title = 'Work',
                         icon = 'briefcase',
                         items = {}
                     }
                 end
-                Config.MenuItems[index].items = Config.JobInteractions[PlayerData.job.name]
+                Config.MenuItems[4].items = Config.JobInteractions[PlayerData.job.name]
             end
         end
     else
         if Config.JobInteractions[PlayerData.job.name] and
             next(Config.JobInteractions[PlayerData.job.name]) then
-            if not Config.MenuItems[index] then
-                Config.MenuItems[index] = {
+            if not Config.MenuItems[4] then
+                Config.MenuItems[4] = {
                     id = 'jobinteractions',
                     title = 'Work',
                     icon = 'briefcase',
                     items = {}
                 }
             end
-            Config.MenuItems[index].items = Config.JobInteractions[PlayerData.job.name]
+            Config.MenuItems[4].items = Config.JobInteractions[PlayerData.job.name]
+        else
+            Config.MenuItems[4] = nil
         end
     end
 end
 
-local function SetupVehicleMenu(ped)
-    local Vehicle = GetVehiclePedIsIn(ped)
+local function SetupVehicleMenu()
+    local Vehicle = GetVehiclePedIsIn(PlayerPedId())
     if Vehicle ~= 0 then
         local AmountOfSeats = GetVehicleModelNumberOfSeats(GetEntityModel(Vehicle))
         if AmountOfSeats == 2 then
@@ -147,9 +147,8 @@ local function SetupVehicleMenu(ped)
 end
 
 local function setupSubItems()
-    local ped = PlayerPedId()
     SetupJobMenu()
-    SetupVehicleMenu(ped)
+    SetupVehicleMenu()
 end
 
 local function deepcopy(orig) -- modified the deep copy function from http://lua-users.org/wiki/CopyTable
@@ -195,10 +194,7 @@ end
 
 local function setRadialState(bool, sendMessage, delay)
     -- Menuitems have to be added only once
-    if not radialMenuSetup then
-        setupSubItems()
-        radialMenuSetup = true
-    end
+    setupSubItems()
     
     local items
     if bool then

--- a/client/main.lua
+++ b/client/main.lua
@@ -2,154 +2,12 @@ QBCore = exports['qb-core']:GetCoreObject()
 PlayerData = QBCore.Functions.GetPlayerData() -- Setting this for when you restart the resource in game
 local inRadialMenu = false
 
+local jobIndex = nil
+local vehicleIndex = nil
+
+local DynamicMenuItems = {}
+local FinalMenuItems = {}
 -- Functions
-
-local function SetupJobMenu()
-    if PlayerData.metadata["isdead"] then
-        if PlayerData.job.name == "police" or PlayerData.job.name == "ambulance" then
-            if not Config.MenuItems[4] then
-                Config.MenuItems[4] = {
-                    id = 'jobinteractions',
-                    title = 'Work',
-                    icon = 'briefcase',
-                    items = {}
-                }
-            end
-            Config.MenuItems[4].items = {
-                [1] = {
-                    id = 'emergencybutton2',
-                    title = Lang:t("options.emergency_button"),
-                    icon = '#general',
-                    type = 'client',
-                    event = 'police:client:SendPoliceEmergencyAlert',
-                    shouldClose = true,
-                },
-            }
-        else
-            if Config.JobInteractions[PlayerData.job.name] and
-                next(Config.JobInteractions[PlayerData.job.name]) then
-                if not Config.MenuItems[4] then
-                    Config.MenuItems[4] = {
-                        id = 'jobinteractions',
-                        title = 'Work',
-                        icon = 'briefcase',
-                        items = {}
-                    }
-                end
-                Config.MenuItems[4].items = Config.JobInteractions[PlayerData.job.name]
-            end
-        end
-    else
-        if Config.JobInteractions[PlayerData.job.name] and
-            next(Config.JobInteractions[PlayerData.job.name]) then
-            if not Config.MenuItems[4] then
-                Config.MenuItems[4] = {
-                    id = 'jobinteractions',
-                    title = 'Work',
-                    icon = 'briefcase',
-                    items = {}
-                }
-            end
-            Config.MenuItems[4].items = Config.JobInteractions[PlayerData.job.name]
-        else
-            Config.MenuItems[4] = nil
-        end
-    end
-end
-
-local function SetupVehicleMenu()
-    local Vehicle = GetVehiclePedIsIn(PlayerPedId())
-    if Vehicle ~= 0 then
-        local AmountOfSeats = GetVehicleModelNumberOfSeats(GetEntityModel(Vehicle))
-        if AmountOfSeats == 2 then
-            Config.MenuItems[3].items[3].items = {
-                [1] = {
-                    id = -1,
-                    title = Lang:t("options.driver_seat"),
-                    icon = 'caret-up',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-                [2] = {
-                    id = 0,
-                    title = Lang:t("options.passenger_seat"),
-                    icon = 'caret-up',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-            }
-        elseif AmountOfSeats == 3 then
-            Config.MenuItems[3].items[3].items = {
-                [4] = {
-                    id = -1,
-                    title = Lang:t("options.driver_seat"),
-                    icon = 'caret-up',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-                [1] = {
-                    id = 0,
-                    title = Lang:t("options.passenger_seat"),
-                    icon = 'caret-up',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-                [3] = {
-                    id = 1,
-                    title = Lang:t("options.other_seats"),
-                    icon = 'caret-down',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-            }
-        elseif AmountOfSeats == 4 then
-            Config.MenuItems[3].items[3].items = {
-                [4] = {
-                    id = -1,
-                    title = Lang:t("options.driver_seat"),
-                    icon = 'caret-up',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-                [1] = {
-                    id = 0,
-                    title = Lang:t("options.passenger_seat"),
-                    icon = 'caret-up',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-                [3] = {
-                    id = 1,
-                    title = Lang:t("options.rear_left_seat"),
-                    icon = 'caret-down',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-                [2] = {
-                    id = 2,
-                    title = Lang:t("options.rear_right_seat"),
-                    icon = 'caret-down',
-                    type = 'client',
-                    event = 'qb-radialmenu:client:ChangeSeat',
-                    shouldClose = false,
-                },
-            }
-        end
-    end
-end
-
-local function setupSubItems()
-    SetupJobMenu()
-    SetupVehicleMenu()
-end
 
 local function deepcopy(orig) -- modified the deep copy function from http://lua-users.org/wiki/CopyTable
     local orig_type = type(orig)
@@ -178,6 +36,111 @@ local function deepcopy(orig) -- modified the deep copy function from http://lua
     return copy
 end
 
+local function getNearestVeh()
+    local pos = GetEntityCoords(PlayerPedId())
+    local entityWorld = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 20.0, 0.0)
+    local rayHandle = CastRayPointToPoint(pos.x, pos.y, pos.z, entityWorld.x, entityWorld.y, entityWorld.z, 10, PlayerPedId(), 0)
+    local _, _, _, _, vehicleHandle = GetRaycastResult(rayHandle)
+    return vehicleHandle
+end
+
+local function AddOption(data, id)
+    local menuID = id ~= nil and id or (#DynamicMenuItems + 1)
+    DynamicMenuItems[menuID] = deepcopy(data)
+    return menuID
+end
+
+local function RemoveOption(id)
+    DynamicMenuItems[id] = nil
+end
+
+local function SetupJobMenu()
+    local JobMenu = {
+        id = 'jobinteractions',
+        title = 'Work',
+        icon = 'briefcase',
+        items = {}
+    }
+    if PlayerData.metadata["isdead"] and (PlayerData.job.name == "police" or PlayerData.job.name == "ambulance") then
+        JobMenu.items = {
+            [1] = {
+                id = 'emergencybutton2',
+                title = Lang:t("options.emergency_button"),
+                icon = '#general',
+                type = 'client',
+                event = 'police:client:SendPoliceEmergencyAlert',
+                shouldClose = true,
+            },
+        }
+    elseif Config.JobInteractions[PlayerData.job.name] and next(Config.JobInteractions[PlayerData.job.name]) then
+        JobMenu.items = Config.JobInteractions[PlayerData.job.name]
+    end
+
+    if #JobMenu.items == 0 then
+        if jobIndex then
+            RemoveOption(jobIndex)
+            jobIndex = nil
+        end
+    else
+        jobIndex = AddOption(JobMenu, jobIndex)
+    end
+end
+
+local function SetupVehicleMenu()
+    local VehicleMenu = {
+        id = 'vehicle',
+        title = 'Vehicle',
+        icon = 'car',
+        items = {}
+    }
+
+    local ped = PlayerPedId()
+    local Vehicle = GetVehiclePedIsIn(ped) ~= 0 and GetVehiclePedIsIn(ped) or getNearestVeh()
+    if Vehicle ~= 0 then
+        VehicleMenu.items[#VehicleMenu.items+1] = Config.VehicleDoors
+        if Config.EnableExtraMenu then VehicleMenu.items[#VehicleMenu.items+1] = Config.VehicleExtras end
+
+        if IsPedInAnyVehicle(ped) then
+            local seatIndex = #VehicleMenu.items+1
+            VehicleMenu.items[seatIndex] = deepcopy(Config.VehicleSeats)
+
+            local seatTable = {
+                [1] = Lang:t("options.driver_seat"),
+                [2] = Lang:t("options.passenger_seat"),
+                [3] = Lang:t("options.rear_left_seat"),
+                [4] = Lang:t("options.rear_right_seat"),
+            }
+
+            local AmountOfSeats = GetVehicleModelNumberOfSeats(GetEntityModel(Vehicle))
+            for i = 1, AmountOfSeats do
+                local newIndex = #VehicleMenu.items[seatIndex].items+1
+                VehicleMenu.items[seatIndex].items[newIndex] = {
+                    id = i - 2,
+                    title = seatTable[i] or Lang:t("options.other_seats"),
+                    icon = 'caret-up',
+                    type = 'client',
+                    event = 'qb-radialmenu:client:ChangeSeat',
+                    shouldClose = false,
+                }
+            end
+        end
+    end
+
+    if #VehicleMenu.items == 0 then
+        if vehicleIndex then
+            RemoveOption(vehicleIndex)
+            vehicleIndex = nil
+        end
+    else
+        vehicleIndex = AddOption(VehicleMenu, vehicleIndex)
+    end
+end
+
+local function SetupSubItems()
+    SetupJobMenu()
+    SetupVehicleMenu()
+end
+
 local function selectOption(t, t2)
     for k, v in pairs(t) do
         if v.items then
@@ -194,33 +157,30 @@ end
 
 local function setRadialState(bool, sendMessage, delay)
     -- Menuitems have to be added only once
-    setupSubItems()
-    
-    local items
+
     if bool then
+        FinalMenuItems = {}
+
+        SetupSubItems()
+        FinalMenuItems = deepcopy(Config.MenuItems)
+        for _, v in pairs(DynamicMenuItems) do
+            FinalMenuItems[#FinalMenuItems+1] = v
+        end
         TriggerEvent('qb-radialmenu:client:onRadialmenuOpen')
-        items = deepcopy(Config.MenuItems)
     else
         TriggerEvent('qb-radialmenu:client:onRadialmenuClose')
     end
+
     SetNuiFocus(bool, bool)
     if sendMessage then
         SendNUIMessage({
             action = "ui",
             radial = bool,
-            items = items
+            items = FinalMenuItems
         })
     end
     if delay then Wait(500) end
     inRadialMenu = bool
-end
-
-local function getNearestVeh()
-    local pos = GetEntityCoords(PlayerPedId())
-    local entityWorld = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 20.0, 0.0)
-    local rayHandle = CastRayPointToPoint(pos.x, pos.y, pos.z, entityWorld.x, entityWorld.y, entityWorld.z, 10, PlayerPedId(), 0)
-    local _, _, _, _, vehicleHandle = GetRaycastResult(rayHandle)
-    return vehicleHandle
 end
 
 -- Command
@@ -239,7 +199,6 @@ RegisterKeyMapping('radialmenu', Lang:t("general.command_description"), 'keyboar
 -- Sets the metadata when the player spawns
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     PlayerData = QBCore.Functions.GetPlayerData()
-    setupSubItems()
 end)
 
 -- Sets the playerdata to an empty table when the player has quit or did /logout
@@ -340,7 +299,7 @@ RegisterNetEvent('qb-radialmenu:client:ChangeSeat', function(data)
         if IsSeatFree then
             if kmh <= 100.0 then
                 SetPedIntoVehicle(PlayerPedId(), Veh, data.id)
-                QBCore.Functions.Notify(Lang:t("info.switched_seats"), {seat = data.title})
+                QBCore.Functions.Notify(Lang:t("info.switched_seats", {seat = data.title}))
             else
                 QBCore.Functions.Notify(Lang:t("error.vehicle_driving_fast"), 'error')
             end
@@ -360,7 +319,8 @@ end)
 
 RegisterNUICallback('selectItem', function(data)
     local itemData = data.itemData
-    local found, action = selectOption(Config.MenuItems, itemData)
+    local found, action = selectOption(FinalMenuItems, itemData)
+
     if itemData and found then
         if action then
             action(itemData)
@@ -376,12 +336,5 @@ RegisterNUICallback('selectItem', function(data)
     end
 end)
 
-exports('AddOption', function(data, id)
-    local menuId = id ~= nil and id or (#Config.MenuItems + 1)
-    Config.MenuItems[menuId] = data
-    return menuId
- end)
- 
- exports('RemoveOption', function(id)
-    Config.MenuItems[id] = nil
- end)
+exports('AddOption', AddOption)
+exports('RemoveOption', RemoveOption)

--- a/client/stretcher.lua
+++ b/client/stretcher.lua
@@ -83,7 +83,7 @@ local function LayOnStretcher()
         loadAnim(inBedDicts)
         if stretcherObject and #(coords - GetEntityCoords(stretcherObject)) <= 3.0 then
             TaskPlayAnim(PlayerPedId(), inBedDicts, inBedAnims, 8.0, 8.0, -1, 69, 1, false, false, false)
-            AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.0, 0.0, 0.0, 180.0, 0.0, false, false, false, false, 2, true)
+            AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.0, 0.0, 0.0, 180.0, 0.0, false, false, false, false, 2)
             isLayingOnBed = true
         end
     else
@@ -93,7 +93,7 @@ local function LayOnStretcher()
             loadAnim(inBedDicts)
             if stretcherObject and #(coords - GetEntityCoords(stretcherObject)) <= 3.0 then
                 TaskPlayAnim(PlayerPedId(), inBedDicts, inBedAnims, 8.0, 8.0, -1, 69, 1, false, false, false)
-                AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.6, 0.0, 0.0, 360.0, 0.0, false, false, false, false, 2, true)
+                AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.6, 0.0, 0.0, 360.0, 0.0, false, false, false, false, 2)
                 isLayingOnBed = true
             end
         end
@@ -118,7 +118,7 @@ local function attachToStretcher()
             loadAnim("anim@heists@box_carry@")
             TaskPlayAnim(ped, 'anim@heists@box_carry@', 'idle', 8.0, 8.0, -1, 50, 0, false, false, false)
             SetTimeout(150, function()
-                AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -0.50, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2, true)
+                AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -0.50, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2)
             end)
             FreezeEntityPosition(stretcherObject, false)
         else
@@ -129,7 +129,7 @@ local function attachToStretcher()
                 loadAnim("anim@heists@box_carry@")
                 TaskPlayAnim(ped, 'anim@heists@box_carry@', 'idle', 8.0, 8.0, -1, 50, 0, false, false, false)
                 SetTimeout(150, function()
-                    AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -1.0, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2, true)
+                    AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -1.0, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2)
                 end)
                 FreezeEntityPosition(stretcherObject, false)
             end
@@ -218,7 +218,6 @@ RegisterNetEvent('qb-radialmenu:Stretcher:client:BusyCheck', function(otherId, t
     local ped = PlayerPedId()
     if type == "lay" then
         loadAnim("anim@gangops@morgue@table@")
-        IsEntityPlayingAnim(entity, animDict, animName, p4)
         if IsEntityPlayingAnim(ped, "anim@gangops@morgue@table@", "ko_front", 3) then
             TriggerServerEvent('qb-radialmenu:server:BusyResult', true, otherId, type)
         else
@@ -243,7 +242,7 @@ RegisterNetEvent('qb-radialmenu:client:Result', function(isBusy, type)
             NetworkRequestControlOfEntity(stretcherObject)
             loadAnim(inBedDicts)
             TaskPlayAnim(ped, inBedDicts, inBedAnims, 8.0, 8.0, -1, 69, 1, false, false, false)
-            AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.6, 0.0, 0.0, 360.0, 0.0, false, false, false, false, 2, true)
+            AttachEntityToEntity(ped, stretcherObject, 0, 0, 0.0, 1.6, 0.0, 0.0, 360.0, 0.0, false, false, false, false, 2)
             isLayingOnBed = true
         else
             QBCore.Functions.Notify(Lang:t("error.stretcher_in_use"), "error")
@@ -255,7 +254,7 @@ RegisterNetEvent('qb-radialmenu:client:Result', function(isBusy, type)
             loadAnim("anim@heists@box_carry@")
             TaskPlayAnim(ped, 'anim@heists@box_carry@', 'idle', 8.0, 8.0, -1, 50, 0, false, false, false)
             SetTimeout(150, function()
-                AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -1.0, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2, true)
+                AttachEntityToEntity(stretcherObject, ped, GetPedBoneIndex(ped, 28422), 0.0, -1.0, -1.0, 195.0, 180.0, 180.0, 90.0, false, false, true, false, 2)
             end)
             FreezeEntityPosition(stretcherObject, false)
             isAttached = true
@@ -371,6 +370,8 @@ CreateThread(function()
     local ped = PlayerPedId()
     local pos = GetEntityCoords(ped)
     local object = GetClosestObjectOfType(pos.x, pos.y, pos.z, 5.0, `prop_ld_binbag_01`, false, false, false)
-    DeleteObject(object)
-    ClearPedTasksImmediately(ped)
+    if object ~= 0 then
+        DeleteObject(object)
+        ClearPedTasksImmediately(ped)
+    end
 end)

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,7 @@
 Config = {}
 
+Config.EnableExtraMenu = true
+
 Config.MenuItems = {
     [1] = {
         id = 'citizen',
@@ -292,175 +294,164 @@ Config.MenuItems = {
             }
         }
     },
-    [3] = {
-        id = 'vehicle',
-        title = 'Vehicle',
-        icon = 'car',
-        items = {
-            {
-                id = 'vehicledoors',
-                title = 'Vehicle Doors',
-                icon = 'car-side',
-                items = {
-                    {
-                        id = 'door0',
-                        title = 'Drivers door',
-                        icon = 'car-side',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:openDoor',
-                        shouldClose = false
-                    }, {
-                        id = 'door4',
-                        title = 'Hood',
-                        icon = 'car',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:openDoor',
-                        shouldClose = false
-                    }, {
-                        id = 'door1',
-                        title = 'Passengers door',
-                        icon = 'car-side',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:openDoor',
-                        shouldClose = false
-                    }, {
-                        id = 'door3',
-                        title = 'Right rear',
-                        icon = 'car-side',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:openDoor',
-                        shouldClose = false
-                    }, {
-                        id = 'door5',
-                        title = 'Trunk',
-                        icon = 'car',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:openDoor',
-                        shouldClose = false
-                    }, {
-                        id = 'door2',
-                        title = 'Left rear',
-                        icon = 'car-side',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:openDoor',
-                        shouldClose = false
-                    }
-                }
-            }, {
-                id = 'vehicleextras',
-                title = 'Vehicle Extras',
-                icon = 'plus',
-                items = {
-                    {
-                        id = 'extra1',
-                        title = 'Extra 1',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra2',
-                        title = 'Extra 2',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra3',
-                        title = 'Extra 3',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra4',
-                        title = 'Extra 4',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra5',
-                        title = 'Extra 5',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra6',
-                        title = 'Extra 6',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra7',
-                        title = 'Extra 7',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra8',
-                        title = 'Extra 8',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra9',
-                        title = 'Extra 9',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra10',
-                        title = 'Extra 10',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra11',
-                        title = 'Extra 11',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra12',
-                        title = 'Extra 12',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }, {
-                        id = 'extra13',
-                        title = 'Extra 13',
-                        icon = 'box-open',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:setExtra',
-                        shouldClose = false
-                    }
-                }
-            }, {
-                id = 'vehicleseats',
-                title = 'Vehicle Seats',
-                icon = 'chair',
-                items = {
-                    {
-                        id = 'door0',
-                        title = 'Driver',
-                        icon = 'chair',
-                        type = 'client',
-                        event = 'qb-radialmenu:client:ChangeSeat',
-                        shouldClose = false
-                    }
-                }
-            }
+}
+
+Config.VehicleDoors = {
+    id = 'vehicledoors',
+    title = 'Vehicle Doors',
+    icon = 'car-side',
+    items = {
+        {
+            id = 'door0',
+            title = 'Drivers door',
+            icon = 'car-side',
+            type = 'client',
+            event = 'qb-radialmenu:client:openDoor',
+            shouldClose = false
+        }, {
+            id = 'door4',
+            title = 'Hood',
+            icon = 'car',
+            type = 'client',
+            event = 'qb-radialmenu:client:openDoor',
+            shouldClose = false
+        }, {
+            id = 'door1',
+            title = 'Passengers door',
+            icon = 'car-side',
+            type = 'client',
+            event = 'qb-radialmenu:client:openDoor',
+            shouldClose = false
+        }, {
+            id = 'door3',
+            title = 'Right rear',
+            icon = 'car-side',
+            type = 'client',
+            event = 'qb-radialmenu:client:openDoor',
+            shouldClose = false
+        }, {
+            id = 'door5',
+            title = 'Trunk',
+            icon = 'car',
+            type = 'client',
+            event = 'qb-radialmenu:client:openDoor',
+            shouldClose = false
+        }, {
+            id = 'door2',
+            title = 'Left rear',
+            icon = 'car-side',
+            type = 'client',
+            event = 'qb-radialmenu:client:openDoor',
+            shouldClose = false
         }
-    },
+    }
+}
+
+Config.VehicleExtras = {
+    id = 'vehicleextras',
+    title = 'Vehicle Extras',
+    icon = 'plus',
+    items = {
+        {
+            id = 'extra1',
+            title = 'Extra 1',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra2',
+            title = 'Extra 2',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra3',
+            title = 'Extra 3',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra4',
+            title = 'Extra 4',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra5',
+            title = 'Extra 5',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra6',
+            title = 'Extra 6',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra7',
+            title = 'Extra 7',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra8',
+            title = 'Extra 8',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra9',
+            title = 'Extra 9',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra10',
+            title = 'Extra 10',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra11',
+            title = 'Extra 11',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra12',
+            title = 'Extra 12',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }, {
+            id = 'extra13',
+            title = 'Extra 13',
+            icon = 'box-open',
+            type = 'client',
+            event = 'qb-radialmenu:client:setExtra',
+            shouldClose = false
+        }
+    }
+}
+
+Config.VehicleSeats = {
+    id = 'vehicleseats',
+    title = 'Vehicle Seats',
+    icon = 'chair',
+    items = {}
 }
 
 Config.JobInteractions = {

--- a/html/js/RadialMenu.js
+++ b/html/js/RadialMenu.js
@@ -47,11 +47,11 @@ RadialMenu.prototype.open = function () {
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-RadialMenu.prototype.close = function () {
+RadialMenu.prototype.close = function (bool) {
     var self = this;
 
     if (self.currentMenu) {
-        $.post('https://qb-radialmenu/closeRadial');
+        $.post(`https://qb-radialmenu/closeRadial`, JSON.stringify({ delay: bool }) );
         var parentMenu;
         while (parentMenu = self.parentMenu.pop()) {
             parentMenu.remove();

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -35,6 +35,7 @@ function createMenu(items) {
     });
 }
 
+// Close on escape pressed
 $(document).on('keydown', function(e) {
     switch(e.key) {
         case "Escape":
@@ -43,10 +44,12 @@ $(document).on('keydown', function(e) {
     }
 });
 
+// Close on any key up, hold/release support incase user changes keybind on the fivem side
 $(document).on('keyup', function(e) {
-    switch(e.key) {
-        case "F1":
-            QBRadialMenu.close();
-            break;
-    }
+    QBRadialMenu.close();
+    // switch(e.key) {
+    //     case "F1":
+    //         QBRadialMenu.close();
+    //         break;
+    // }
 });

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -10,7 +10,7 @@ $(document).ready(function(){
                     createMenu(event.data.items)
                     QBRadialMenu.open();
                 } else {
-                    QBRadialMenu.close();
+                    QBRadialMenu.close(true);
                 }
         }
     });
@@ -23,7 +23,7 @@ function createMenu(items) {
         menuItems   : items,
         onClick     : function(item) {
             if (item.shouldClose) {
-                QBRadialMenu.close();
+                QBRadialMenu.close(true);
             }
             
             if (item.items == null && item.shouldClose != null) {
@@ -38,6 +38,13 @@ function createMenu(items) {
 $(document).on('keydown', function(e) {
     switch(e.key) {
         case "Escape":
+            QBRadialMenu.close();
+            break;
+    }
+});
+
+$(document).on('keyup', function(e) {
+    switch(e.key) {
         case "F1":
             QBRadialMenu.close();
             break;


### PR DESCRIPTION
This update also contains the required code for the Customs polyzone update found here:
https://github.com/qbcore-framework/qb-customs/pull/71

- Can now dynamically add/remove entries to the menu, use the SetupCustomsMenu() function as an example
- Radial menu is now a hold/release instead of a toggle. Holding f1 keeps the menu open while letting it go closes it