### PR TITLE
Fixed issue where floats were turned into integers

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -335,8 +335,6 @@ RegisterNUICallback('selectItem', function(data)
     local itemData = data.itemData
     local found, action, data = selectOption(FinalMenuItems, itemData)
 
-    print(dump(data))
-
     if data and found then
         if action then
             action(data)

--- a/client/main.lua
+++ b/client/main.lua
@@ -133,11 +133,11 @@ end
 local function selectOption(t, t2)
     for k, v in pairs(t) do
         if v.items then
-            local found, hasAction = selectOption(v.items, t2)
-            if found then return true, hasAction end
+            local found, hasAction, val = selectOption(v.items, t2)
+            if found then return true, hasAction, val end
         else
             if v.id == t2.id and ((v.event and v.event == t2.event) or v.action) and (not v.canOpen or v.canOpen()) then
-                return true, v.action
+                return true, v.action, v
             end
         end
     end
@@ -333,19 +333,21 @@ end)
 
 RegisterNUICallback('selectItem', function(data)
     local itemData = data.itemData
-    local found, action = selectOption(FinalMenuItems, itemData)
+    local found, action, data = selectOption(FinalMenuItems, itemData)
 
-    if itemData and found then
+    print(dump(data))
+
+    if data and found then
         if action then
-            action(itemData)
-        elseif itemData.type == 'client' then
-            TriggerEvent(itemData.event, itemData)
-        elseif itemData.type == 'server' then
-            TriggerServerEvent(itemData.event, itemData)
-        elseif itemData.type == 'command' then
-            ExecuteCommand(itemData.event)
-        elseif itemData.type == 'qbcommand' then
-            TriggerServerEvent('QBCore:CallCommand', itemData.event, itemData)
+            action(data)
+        elseif data.type == 'client' then
+            TriggerEvent(data.event, data)
+        elseif data.type == 'server' then
+            TriggerServerEvent(data.event, data)
+        elseif data.type == 'command' then
+            ExecuteCommand(data.event)
+        elseif data.type == 'qbcommand' then
+            TriggerServerEvent('QBCore:CallCommand', data.event, data)
         end
     end
 end)


### PR DESCRIPTION
When adding something like a vector containing the float 1.0 as additional info, javascript would turn this into 1 with JSON.stringify. This fixes the issue by using the configured value instead of the value returned from the NUI callback which has been stringified by javascript.