### PR TITLE
Police objects menu bug

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -658,7 +658,7 @@ Config.JobInteractions = {
                 }, {
                     id = 'spawnschotten',
                     title = 'Speed Limit Sign',
-                    icon = 'sign',
+                    icon = 'sign-hanging',
                     type = 'client',
                     event = 'police:client:spawnRoadSign',
                     shouldClose = false


### PR DESCRIPTION
The icon does not exist -> replaced with 'sign-hanging'

otherwise menu is still stuck in the "Police Actions" menu