### PR TITLE
Made sure jobs cannot use their menu actions when offduty

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -61,7 +61,7 @@ local function SetupJobMenu()
         icon = 'briefcase',
         items = {}
     }
-    if Config.JobInteractions[PlayerData.job.name] and next(Config.JobInteractions[PlayerData.job.name]) then
+    if Config.JobInteractions[PlayerData.job.name] and next(Config.JobInteractions[PlayerData.job.name]) and PlayerData.job.onduty then
         JobMenu.items = Config.JobInteractions[PlayerData.job.name]
     end
 


### PR DESCRIPTION
**Describe Pull request**
Added a check to make sure that any player who is not onduty can't use their menu/job actions. Before it did not make any sense that players which were offduty could perform their regular job actions.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
--> Yes, it does work fine.
- Does your code fit the style guidelines?
--> Yes, only one line edited.
- Does your PR fit the contribution guidelines?
--> Yes, I guess so.
