### PR TITLE
Fix "flip vehicle" not working

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -344,7 +344,7 @@ RegisterNetEvent('qb-radialmenu:flipVehicle', function()
         disableMouse = false,
         disableCombat = true,
     }, {}, {}, {}, function() -- Done
-        local vehicle = getNearestVeh()
+        local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
         SetVehicleOnGroundProperly(vehicle)
         TriggerEvent('animations:client:EmoteCommandStart', {"c"})
     end, function() -- Cancel


### PR DESCRIPTION
**Describe Pull request**
We received a bug report that the "flip vehicle" option weren't working, and I looked into it. It wasn't working with the previous function for getting the vehicle, and I replaced it to get the vehicle the ped is in - and now it's working.
So it's basically fixing a function not working.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
