### PR TITLE
Updating Radialmenu to allow walking whilst using

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -7,6 +7,8 @@ local vehicleIndex = nil
 
 local DynamicMenuItems = {}
 local FinalMenuItems = {}
+local controlsToToggle = {24,0,1,2, 142, 257, 346} -- if not using toggle
+
 -- Functions
 
 local function deepcopy(orig) -- modified the deep copy function from http://lua-users.org/wiki/CopyTable
@@ -186,22 +188,46 @@ local function SetupRadialMenu()
     end
 end
 
-local function setRadialState(bool, sendMessage, delay)
-    -- Menuitems have to be added only once
-
-    if bool then
-        TriggerEvent('qb-radialmenu:client:onRadialmenuOpen')
-        SetupRadialMenu()
-    else
-        TriggerEvent('qb-radialmenu:client:onRadialmenuClose')
+local function controlToggle(bool)
+    for i = 1, #controlsToToggle,1 do
+        if bool then
+            exports['qb-smallresources']:addDisableControls(controlsToToggle[i])
+        else
+            exports['qb-smallresources']:removeDisableControls(controlsToToggle[i])
+        end
     end
+end
 
-    SetNuiFocus(bool, bool)
+
+local function setRadialState(bool, sendMessage, delay)
+        -- Menuitems have to be added only once
+    if Config.UseWalking then 
+        if bool then
+            SetupRadialMenu()
+            PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)
+            controlToggle(true)
+        else
+            controlToggle(false)
+        end
+        SetNuiFocus(bool, bool)
+        SetNuiFocusKeepInput(bool, true)
+    else
+        if bool then
+            TriggerEvent('qb-radialmenu:client:onRadialmenuOpen')
+            SetupRadialMenu()
+        else
+            TriggerEvent('qb-radialmenu:client:onRadialmenuClose')
+        end
+        SetNuiFocus(bool, bool)
+    end
+    
     if sendMessage then
         SendNUIMessage({
             action = "ui",
             radial = bool,
-            items = FinalMenuItems
+            items = FinalMenuItems,
+            toggle = Config.Toggle,
+            keybind = Config.Keybind
         })
     end
     if delay then Wait(500) end
@@ -217,7 +243,7 @@ RegisterCommand('radialmenu', function()
     end
 end)
 
-RegisterKeyMapping('radialmenu', Lang:t("general.command_description"), 'keyboard', 'F1')
+RegisterKeyMapping('radialmenu', Lang:t("general.command_description"), 'keyboard', Config.Keybind)
 
 -- Events
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -201,7 +201,7 @@ end
 
 local function setRadialState(bool, sendMessage, delay)
         -- Menuitems have to be added only once
-    if Config.UseWalking then
+    if Config.UseWhilstWalking then 
         if bool then
             SetupRadialMenu()
             PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)

--- a/client/main.lua
+++ b/client/main.lua
@@ -202,7 +202,7 @@ end
 local function setRadialState(bool, sendMessage, delay)
         -- Menuitems have to be added only once
     if Config.UseWhilstWalking then 
-        if bool then
+            if bool then
             SetupRadialMenu()
             PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)
             controlToggle(true)

--- a/client/main.lua
+++ b/client/main.lua
@@ -201,7 +201,7 @@ end
 
 local function setRadialState(bool, sendMessage, delay)
         -- Menuitems have to be added only once
-    if Config.UseWalking then 
+    if Config.UseWalking then
         if bool then
             SetupRadialMenu()
             PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)

--- a/client/main.lua
+++ b/client/main.lua
@@ -90,7 +90,7 @@ local function SetupVehicleMenu()
     if Vehicle ~= 0 then
         VehicleMenu.items[#VehicleMenu.items+1] = Config.VehicleDoors
         if Config.EnableExtraMenu then VehicleMenu.items[#VehicleMenu.items+1] = Config.VehicleExtras end
-        
+
         if not IsVehicleOnAllWheels(Vehicle) then
             VehicleMenu.items[#VehicleMenu.items+1] = {
                 id = 'vehicle-flip',
@@ -201,7 +201,7 @@ end
 
 local function setRadialState(bool, sendMessage, delay)
         -- Menuitems have to be added only once
-    if Config.UseWhilstWalking then 
+    if Config.UseWhilstWalking then
             if bool then
             SetupRadialMenu()
             PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)
@@ -220,7 +220,7 @@ local function setRadialState(bool, sendMessage, delay)
         end
         SetNuiFocus(bool, bool)
     end
-    
+
     if sendMessage then
         SendNUIMessage({
             action = "ui",

--- a/client/main.lua
+++ b/client/main.lua
@@ -202,7 +202,7 @@ end
 local function setRadialState(bool, sendMessage, delay)
         -- Menuitems have to be added only once
     if Config.UseWhilstWalking then
-            if bool then
+        if bool then
             SetupRadialMenu()
             PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)
             controlToggle(true)

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,7 @@
 Config = {}
-
+Config.Keybind = 'F1' -- FiveM Keyboard, this is registered keymapping, so needs changed in keybindings if player already has this mapped.
+Config.Toggle = false -- use toggle mode. False requires hold of key
+Config.UseWalking = true -- use whilst walking
 Config.EnableExtraMenu = true
 Config.Fliptime = 15000
 

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
 Config.Keybind = 'F1' -- FiveM Keyboard, this is registered keymapping, so needs changed in keybindings if player already has this mapped.
-Config.Toggle = true -- use toggle mode. False requires hold of key
+Config.Toggle = false -- use toggle mode. False requires hold of key
 Config.UseWhilstWalking = false -- use whilst walking
 Config.EnableExtraMenu = true
 Config.Fliptime = 15000

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 Config = {}
 Config.Keybind = 'F1' -- FiveM Keyboard, this is registered keymapping, so needs changed in keybindings if player already has this mapped.
-Config.Toggle = false -- use toggle mode. False requires hold of key
-Config.UseWalking = true -- use whilst walking
+Config.Toggle = true -- use toggle mode. False requires hold of key
+Config.UseWhilstWalking = false -- use whilst walking
 Config.EnableExtraMenu = true
 Config.Fliptime = 15000
 

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -30,7 +30,6 @@ $(document).ready(function(){
                         }
                     });
                  }
-                
         }
     });
 });

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -1,17 +1,28 @@
 'use strict';
 
 var QBRadialMenu = null;
-
+var toggleConfig = false;
+var keybindConfig = false;
 $(document).ready(function(){
     window.addEventListener('message', function(event){
         switch (event.data.action) {
             case "ui":
+                toggleConfig = event.data.toggle;
+                keybindConfig = event.data.keybind;
                 if (event.data.radial) {
                     createMenu(event.data.items)
                     QBRadialMenu.open();
                 } else {
                     QBRadialMenu.close(true);
                 }
+                if (toggleConfig === false){
+                     $(document).on('keyup', function(e) {
+                         if(e.key == keybindConfig | e.key === keybindConfig.toLowerCase()){
+                             QBRadialMenu.close();
+                         }
+                     });
+                 }
+                
         }
     });
 });
@@ -42,9 +53,4 @@ $(document).on('keydown', function(e) {
             QBRadialMenu.close();
             break;
     }
-});
-
-// Close on any key up, hold/release support incase user changes keybind on the fivem side
-$(document).on('keyup', function(e) {
-    QBRadialMenu.close();
 });

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -21,12 +21,19 @@ $(document).ready(function(){
                              QBRadialMenu.close();
                          }
                      });
+                 } else {
+                    $(document).on('keydown', function(e) {
+                        switch(e.key) {
+                            case keybindConfig:
+                                QBRadialMenu.close();
+                                break;
+                        }
+                    });
                  }
                 
         }
     });
 });
-
 function createMenu(items) {
     QBRadialMenu = new RadialMenu({
         parent      : document.body,


### PR DESCRIPTION
**Describe Pull request**
Many requests for walking whilst using menu observed on Discord.
Added Toggle and UseWalking config options

Toggle: false = must hold key, true = toggle menu

UseWalking ture = allows player to walk whilst using radialmenu, false = player movement stops

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) Yes
- Does your code fit the style guidelines? [yes/no] Yes
- Does your PR fit the contribution guidelines? [yes/no] Yes
