### PR TITLE
Fix qb-radialmenu:client:onRadialmenuOpen not firing when Config.UseWhilstWalking = true

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -203,10 +203,12 @@ local function setRadialState(bool, sendMessage, delay)
         -- Menuitems have to be added only once
     if Config.UseWhilstWalking then
         if bool then
+            TriggerEvent('qb-radialmenu:client:onRadialmenuOpen')
             SetupRadialMenu()
             PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)
             controlToggle(true)
         else
+            TriggerEvent('qb-radialmenu:client:onRadialmenuClose')
             controlToggle(false)
         end
         SetNuiFocus(bool, bool)


### PR DESCRIPTION
This is a very simple fix (literally two lines) for an issue I've been experiencing since turning `Config.UseWhilstWalking` to `true`.

Some scripts depend on the event `qb-radialmenu:client:onRadialmenuOpen` to add options to the radialmenu. For some reason this event doesn't get fired if `Config.UseWhilstWalking` is set to `true`.

I personally found this when using this script [https://github.com/JonasDev99/qb-garages](https://github.com/JonasDev99/qb-garages).