### PR TITLE
Add arguments to menu items. 

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -393,9 +393,9 @@ RegisterNUICallback('selectItem', function(inData, cb)
         if action then
             action(data)
         elseif data.type == 'client' then
-            TriggerEvent(data.event, data)
+            TriggerEvent(data.event, data.args)
         elseif data.type == 'server' then
-            TriggerServerEvent(data.event, data)
+            TriggerServerEvent(data.event, data.args)
         elseif data.type == 'command' then
             ExecuteCommand(data.event)
         elseif data.type == 'qbcommand' then


### PR DESCRIPTION
I came across this issue when firing an event in my script that had an argument. Radial menu sends all the data it stores, my suggestion is to either not send any args in the radialmenu event trigger or give it an args field like I have done in the PR. 

```lua
{
    id = 'garage',
    title = 'Open garage',
    icon = 'trailer',
    type = 'client',
    event = 'wkd-garages:client:garageMenu',
    args = {arg1 = 'test' , arg2 = 'test2'}, --Not sure if this would actually be useful to anyone or not?
    shouldClose = true
},
```

If your PR is to fix an issue mention that issue here. - No issue has been raised for this.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes (Be honest)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
