### PR TITLE
Fixed an index error

### DIFF
--- a/client/clothing.lua
+++ b/client/clothing.lua
@@ -686,7 +686,7 @@ local drawables = {
 		Table = {Standalone = true, male = 0, female = 0 },
 		Emote = {Dict = "mp_masks@standard_car@ds@", Anim = "put_on_mask", Move = 51, Dur = 800}
 	},
-	["hair"] = {
+	["Hair"] = {
 		Drawable = 2,
 		Table = variations.hair,
 		Remember = true,


### PR DESCRIPTION
**Fixed an index error**

**Error:** ``@qb-radialmenu/client/clothing.lua:819: attempt to index a nil value (local 'Toggle')``
**Solution:** Changed the key from ``hair`` to ``Hair`` as the script tried to index ``drawables``  with the key ``Hair`` and not ``hair``.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes!**
- Does your code fit the style guidelines? **Yes!**
- Does your PR fit the contribution guidelines? **Yes!**
