### PR TITLE
:bug: fixed open and close event not firing

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -204,10 +204,12 @@ local function setRadialState(bool, sendMessage, delay)
     -- Menuitems have to be added only once
     if Config.UseWhilstWalking then
         if bool then
+            TriggerEvent('qb-radialmenu:client:onRadialmenuOpen')
             SetupRadialMenu()
             PlaySoundFrontend(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", 1)
             controlToggle(true)
         else
+            TriggerEvent('qb-radialmenu:client:onRadialmenuClose')
             controlToggle(false)
         end
         SetNuiFocus(bool, bool)


### PR DESCRIPTION
fixed open and close event not firing when Config.UseWhilstWalking is set to true

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
