### PR TITLE
Fix exploitable net events

### DIFF
--- a/server/stretcher.lua
+++ b/server/stretcher.lua
@@ -2,10 +2,14 @@ RegisterNetEvent('qb-radialmenu:server:RemoveStretcher', function(pos, stretcher
     TriggerClientEvent('qb-radialmenu:client:RemoveStretcherFromArea', -1, pos, stretcherObject)
 end)
 
-RegisterNetEvent('qb-radialmenu:Stretcher:BusyCheck', function(id, type)
-    TriggerClientEvent('qb-radialmenu:Stretcher:client:BusyCheck', id, source, type)
+RegisterNetEvent('qb-radialmenu:Stretcher:BusyCheck', function(target, type)
+    local src = source
+    if not IsCloseToTarget(src, target) then return end
+    TriggerClientEvent('qb-radialmenu:Stretcher:client:BusyCheck', target, source, type)
 end)
 
-RegisterNetEvent('qb-radialmenu:server:BusyResult', function(isBusy, otherId, type)
-    TriggerClientEvent('qb-radialmenu:client:Result', otherId, isBusy, type)
+RegisterNetEvent('qb-radialmenu:server:BusyResult', function(isBusy, target, type)
+    local src = source
+    if not IsCloseToTarget(src, target) then return end
+    TriggerClientEvent('qb-radialmenu:client:Result', target, isBusy, type)
 end)

--- a/server/trunk.lua
+++ b/server/trunk.lua
@@ -1,6 +1,11 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local trunkBusy = {}
 
+function IsCloseToTarget(source, target)
+    if not DoesPlayerExist(target) then return false end
+    return #(GetEntityCoords(GetPlayerPed(source)) - GetEntityCoords(GetPlayerPed(target))) < 2.0
+end
+
 RegisterNetEvent('qb-radialmenu:trunk:server:Door', function(open, plate, door)
     TriggerClientEvent('qb-radialmenu:trunk:client:Door', -1, plate, door, open)
 end)
@@ -9,8 +14,10 @@ RegisterNetEvent('qb-trunk:server:setTrunkBusy', function(plate, busy)
     trunkBusy[plate] = busy
 end)
 
-RegisterNetEvent('qb-trunk:server:KidnapTrunk', function(targetId, closestVehicle)
-    TriggerClientEvent('qb-trunk:client:KidnapGetIn', targetId, closestVehicle)
+RegisterNetEvent('qb-trunk:server:KidnapTrunk', function(target, closestVehicle)
+    local src = source
+    if not IsCloseToTarget(src, target) then return end
+    TriggerClientEvent('qb-trunk:client:KidnapGetIn', target, closestVehicle)
 end)
 
 QBCore.Functions.CreateCallback('qb-trunk:server:getTrunkBusy', function(_, cb, plate)


### PR DESCRIPTION
**Describe Pull request**
These events could previously be exploited by bad actors to soft 'freeze' players using the lay animation or force stow them in  a vehicle trunk. This PR fixes this issue by checking if the event source is actually close to the targeted player.

Abusing this event is as simple as this:
` for i = 1, 999 do TriggerServerEvent("qb-radialmenu:server:BusyResult", false, i, "lay") end`

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
--> YES
- Does your code fit the style guidelines?
--> YES
- Does your PR fit the contribution guidelines?
--> YES
