### PR TITLE
feat: add export option

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -41,7 +41,8 @@ end
 local function getNearestVeh()
     local pos = GetEntityCoords(PlayerPedId())
     local entityWorld = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 20.0, 0.0)
-    local rayHandle = CastRayPointToPoint(pos.x, pos.y, pos.z, entityWorld.x, entityWorld.y, entityWorld.z, 10, PlayerPedId(), 0)
+    local rayHandle = CastRayPointToPoint(pos.x, pos.y, pos.z, entityWorld.x, entityWorld.y, entityWorld.z, 10,
+        PlayerPedId(), 0)
     local _, _, _, _, vehicleHandle = GetRaycastResult(rayHandle)
     return vehicleHandle
 end
@@ -405,16 +406,24 @@ RegisterNUICallback('selectItem', function(inData, cb)
     local itemData = inData.itemData
     local found, action, data = selectOption(FinalMenuItems, itemData)
     if data and found then
+        local args = type(data.args) == "table" and table.unpack(data.args) or data
+
         if action then
-            action(data)
+            action(args)
         elseif data.type == 'client' then
-            TriggerEvent(data.event, data)
+            TriggerEvent(data.event, args)
         elseif data.type == 'server' then
-            TriggerServerEvent(data.event, data)
+            TriggerServerEvent(data.event, args)
+        elseif data.type == "export" then
+            local splits = QBCore.Shared.SplitStr(data.export, ".")
+
+            if #splits == 2 then
+                exports[splits[1]][splits[2]](args)
+            end
         elseif data.type == 'command' then
             ExecuteCommand(data.event)
         elseif data.type == 'qbcommand' then
-            TriggerServerEvent('QBCore:CallCommand', data.event, data)
+            TriggerServerEvent('QBCore:CallCommand', data.event, args)
         end
     end
     cb('ok')


### PR DESCRIPTION
**Describe Pull request**
This adds the possibility of using exports in qb-radialmenu, instead of just events.
Also allows the user to customize the arguments the event/export is called with, instead of calling it with the "item" / "option" data

For example:
```lua
{
    id = 'cornerselling',
    title = 'Corner Selling',
    icon = 'cannabis',
    type = 'export',
    export= 'qb-drugs.CornerSelling',
    args = { "hello", "world" },
    shouldClose = true
}
```

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
> No
- Does your code fit the style guidelines?
> Yes
- Does your PR fit the contribution guidelines?
> Yes